### PR TITLE
feat: 프로필 화면에서 사용자 정보 조회 API

### DIFF
--- a/src/main/java/HearDay/spring/domain/article/service/ArticleService.java
+++ b/src/main/java/HearDay/spring/domain/article/service/ArticleService.java
@@ -9,6 +9,7 @@ import HearDay.spring.domain.article.entity.Article;
 import HearDay.spring.domain.article.exception.ArticleException;
 import HearDay.spring.domain.article.repository.ArticleRepository;
 import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.user.repository.UserRepository;
 import HearDay.spring.domain.usercalendar.service.UserCalendarService;
 import HearDay.spring.domain.userrecentarticle.service.UserRecentArticleService;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class ArticleService {
     private final UserRecentArticleService recentArticleService;
     private final ArticleViewCountService articleViewCountService;
     private final UserCalendarService userCalendarService;
+    private final UserRepository userRepository;
     private final WebClient webClient;
 
     @Value("${ai.api.url}")
@@ -56,9 +58,11 @@ public class ArticleService {
             recentArticleService.addRecentArticle(user.getId(), article);
             AgeGroup ageGroup = AgeGroup.fromAge(user.getAge());
             articleViewCountService.incrementViewCount(user.getId(), article.getId(), ageGroup, user.getGender());
-        }
 
-        userCalendarService.checkAttendance(user);
+            userCalendarService.checkAttendance(user);
+            user.addPoint(5);
+            userRepository.save(user);
+        }
 
         return ArticleResponseDto.fromWithDetail(article);
     }

--- a/src/main/java/HearDay/spring/domain/article/service/ArticleService.java
+++ b/src/main/java/HearDay/spring/domain/article/service/ArticleService.java
@@ -9,6 +9,7 @@ import HearDay.spring.domain.article.entity.Article;
 import HearDay.spring.domain.article.exception.ArticleException;
 import HearDay.spring.domain.article.repository.ArticleRepository;
 import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.usercalendar.service.UserCalendarService;
 import HearDay.spring.domain.userrecentarticle.service.UserRecentArticleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final UserRecentArticleService recentArticleService;
     private final ArticleViewCountService articleViewCountService;
+    private final UserCalendarService userCalendarService;
     private final WebClient webClient;
 
     @Value("${ai.api.url}")
@@ -55,6 +57,8 @@ public class ArticleService {
             AgeGroup ageGroup = AgeGroup.fromAge(user.getAge());
             articleViewCountService.incrementViewCount(user.getId(), article.getId(), ageGroup, user.getGender());
         }
+
+        userCalendarService.checkAttendance(user);
 
         return ArticleResponseDto.fromWithDetail(article);
     }

--- a/src/main/java/HearDay/spring/domain/articlequiz/service/ArticleQuizService.java
+++ b/src/main/java/HearDay/spring/domain/articlequiz/service/ArticleQuizService.java
@@ -7,6 +7,7 @@ import HearDay.spring.domain.articlequiz.exception.ArticleQuizException;
 import HearDay.spring.domain.articlequiz.repository.ArticleQuizRepository;
 import HearDay.spring.domain.articlequiz.repository.ArticleQuizUserResultRepository;
 import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class ArticleQuizService {
 
     private final ArticleQuizRepository articleQuizRepository;
     private final ArticleQuizUserResultRepository articleQuizUserResultRepository;
+    private final UserRepository userRepository;
 
     public ArticleQuizDto getArticleQuiz(Long articleId, Long userId) {
         ArticleQuiz quiz = articleQuizRepository.findByArticleId(articleId)
@@ -49,5 +51,8 @@ public class ArticleQuizService {
                 .build();
 
         articleQuizUserResultRepository.save(result);
+
+        user.addPoint(5);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/HearDay/spring/domain/discussion/dto/response/VoiceResponseDto.java
+++ b/src/main/java/HearDay/spring/domain/discussion/dto/response/VoiceResponseDto.java
@@ -2,6 +2,7 @@ package HearDay.spring.domain.discussion.dto.response;
 
 public record VoiceResponseDto(
         String reply,
-        Long discussionId
+        Long discussionId,
+        String title
 ) {
 }

--- a/src/main/java/HearDay/spring/domain/discussion/service/ChatCommandServiceImpl.java
+++ b/src/main/java/HearDay/spring/domain/discussion/service/ChatCommandServiceImpl.java
@@ -16,6 +16,7 @@ import HearDay.spring.domain.discussion.exception.DiscussionException;
 import HearDay.spring.domain.discussion.repository.DiscussionContentRepository;
 import HearDay.spring.domain.discussion.repository.DiscussionRepository;
 import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ public class ChatCommandServiceImpl implements ChatCommandService {
     private final DiscussionRepository discussionRepository;
     private final SpeechToTextService sttService;
     private final TextToSpeechService ttsService;
+    private final UserRepository userRepository;
 
     @Value("${ai.api.url}")
     private String aiUrl;
@@ -60,6 +62,9 @@ public class ChatCommandServiceImpl implements ChatCommandService {
                             .build()
             );
             mode = AiChatModeEnum.OPEN;
+
+            user.addPoint(10);
+            userRepository.save(user);
         } else {
             discussion = discussionRepository.findById(discussionId)
                     .orElseThrow(() -> new DiscussionException.DiscussionNotFoundException(discussionId));
@@ -148,6 +153,9 @@ public class ChatCommandServiceImpl implements ChatCommandService {
                             .build()
             );
             mode = AiChatModeEnum.OPEN;
+
+            user.addPoint(10);
+            userRepository.save(user);
         } else {
             discussion = discussionRepository.findById(discussionId)
                     .orElseThrow(() -> new DiscussionException.DiscussionNotFoundException(discussionId));

--- a/src/main/java/HearDay/spring/domain/discussion/service/ChatCommandServiceImpl.java
+++ b/src/main/java/HearDay/spring/domain/discussion/service/ChatCommandServiceImpl.java
@@ -198,7 +198,8 @@ public class ChatCommandServiceImpl implements ChatCommandService {
 
         return new VoiceResponseDto(
                 outputAudio,
-                discussion.getId()
+                discussion.getId(),
+                article.getTitle()
         );
     }
 }

--- a/src/main/java/HearDay/spring/domain/user/controller/UserController.java
+++ b/src/main/java/HearDay/spring/domain/user/controller/UserController.java
@@ -3,11 +3,7 @@ package HearDay.spring.domain.user.controller;
 import HearDay.spring.common.dto.response.CommonApiResponse;
 import HearDay.spring.common.enums.CategoryEnum;
 import HearDay.spring.domain.user.dto.request.*;
-import HearDay.spring.domain.user.dto.response.AlarmTimeResponse;
-import HearDay.spring.domain.user.dto.response.HomeResponseDto;
-import HearDay.spring.domain.user.dto.response.UserGenderAgeResponseDto;
-import HearDay.spring.domain.user.dto.response.UserLoginResponseDto;
-import HearDay.spring.domain.user.dto.response.UserResponseDto;
+import HearDay.spring.domain.user.dto.response.*;
 import HearDay.spring.domain.user.entity.User;
 import HearDay.spring.domain.user.service.MailService;
 import HearDay.spring.domain.user.service.RefreshTokenService;
@@ -198,5 +194,18 @@ public class UserController {
         userCommandService.updateAlarmTime(user, request.hour(), request.minute(), request.dayType());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonApiResponse.success("알람 시간 설정에 성공했습니다.", null));
+    }
+
+    @GetMapping("/profile")
+    @Operation(summary = "프로필 정보 조회 API")
+    public ResponseEntity<CommonApiResponse<?>> getProfile(
+            @AuthUser User user,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        UserProfileResponseDto result = userQueryService.getUserProfile(user, year, month);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonApiResponse.success("조회에 성공했습니다.", result));
     }
 }

--- a/src/main/java/HearDay/spring/domain/user/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/HearDay/spring/domain/user/dto/response/UserProfileResponseDto.java
@@ -1,0 +1,16 @@
+package HearDay.spring.domain.user.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record UserProfileResponseDto(
+        String nickname,
+        String email,
+        Integer level,
+        Integer point,
+        List<Attendance> attendance
+) {
+    public record Attendance(
+            LocalDate date
+    ) {}
+}

--- a/src/main/java/HearDay/spring/domain/user/entity/User.java
+++ b/src/main/java/HearDay/spring/domain/user/entity/User.java
@@ -36,7 +36,7 @@ public class User extends BaseEntity {
     private String phone;
 
     @Column(nullable = false)
-    private Integer level;
+    private Integer point;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/HearDay/spring/domain/user/entity/User.java
+++ b/src/main/java/HearDay/spring/domain/user/entity/User.java
@@ -87,4 +87,8 @@ public class User extends BaseEntity {
         this.alarmMinute = minute;
         this.alarmDayType = dayType;
     }
+
+    public void addPoint(int amount) {
+        this.point += amount;
+    }
 }

--- a/src/main/java/HearDay/spring/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/HearDay/spring/domain/user/service/UserCommandServiceImpl.java
@@ -45,7 +45,7 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .password(passwordEncoder.encode(request.password()))
                 .email(request.email())
                 .phone(request.phone())
-                .level(1)
+                .point(0)
                 .build();
 
         userRepository.save(user);
@@ -132,7 +132,7 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .password(null)
                 .email(kakaoProfile.kakao_account().email())
                 .phone(null)
-                .level(1)
+                .point(0)
                 .userCategory(null)
                 .build();
         return userRepository.save(user);

--- a/src/main/java/HearDay/spring/domain/user/service/UserQueryService.java
+++ b/src/main/java/HearDay/spring/domain/user/service/UserQueryService.java
@@ -2,6 +2,7 @@ package HearDay.spring.domain.user.service;
 
 import HearDay.spring.domain.user.dto.response.HomeResponseDto;
 import HearDay.spring.domain.user.dto.response.UserGenderAgeResponseDto;
+import HearDay.spring.domain.user.dto.response.UserProfileResponseDto;
 import HearDay.spring.domain.user.entity.User;
 
 public interface UserQueryService {
@@ -9,4 +10,5 @@ public interface UserQueryService {
     User getUserEntity(Long userId);
     HomeResponseDto getHomeInformation(User user);
     UserGenderAgeResponseDto getGenderAndAge(User user);
+    UserProfileResponseDto getUserProfile(User user, int year, int month);
 }

--- a/src/main/java/HearDay/spring/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/HearDay/spring/domain/user/service/UserQueryServiceImpl.java
@@ -4,9 +4,12 @@ import HearDay.spring.domain.article.entity.Article;
 import HearDay.spring.domain.article.repository.ArticleRepository;
 import HearDay.spring.domain.user.dto.response.HomeResponseDto;
 import HearDay.spring.domain.user.dto.response.UserGenderAgeResponseDto;
+import HearDay.spring.domain.user.dto.response.UserProfileResponseDto;
 import HearDay.spring.domain.user.entity.User;
 import HearDay.spring.domain.user.exception.UserException;
 import HearDay.spring.domain.user.repository.UserRepository;
+import HearDay.spring.domain.usercalendar.entity.UserCalendar;
+import HearDay.spring.domain.usercalendar.repository.UserCalendarRepository;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +35,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
     private final ArticleRepository articleRepository;
     private final WebClient webClient;
+    private final UserCalendarRepository userCalendarRepository;
 
     @Value("${ai.api.url}")
     private String aiUrl;
@@ -59,8 +64,11 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         List<HomeResponseDto.ArticleDto> recommendedArticles = fetchRecommendedArticlesFromAiServer(user.getId());
 
+        int point = user.getPoint();
+        int level = calculateLevel(point);
+
         return new HomeResponseDto(
-                user.getLevel(),
+                level,
                 user.getNickname(),
                 formattedDate,
                 recommendedArticles
@@ -125,5 +133,38 @@ public class UserQueryServiceImpl implements UserQueryService {
     @Override
     public UserGenderAgeResponseDto getGenderAndAge(User user) {
         return UserGenderAgeResponseDto.from(user);
+    }
+
+    @Override
+    public UserProfileResponseDto getUserProfile(User user, int year, int month) {
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        List<UserProfileResponseDto.Attendance> attendanceList =
+                userCalendarRepository.findAllByUserAndAttendanceDateBetween(user, startDate, endDate)
+                        .stream()
+                        .map(UserCalendar::getAttendanceDate)
+                        .map(UserProfileResponseDto.Attendance::new)
+                        .toList();
+
+        int point = user.getPoint();
+        int level = calculateLevel(point);
+
+        return new UserProfileResponseDto(
+                user.getNickname(),
+                user.getEmail(),
+                level,
+                point,
+                attendanceList
+        );
+    }
+
+    private int calculateLevel(int point) {
+        if (point < 50) return 1;
+        if (point < 130) return 2;
+        if (point < 250) return 3;
+        if (point < 430) return 4;
+        if (point < 680) return 5;
+        return 6;
     }
 }

--- a/src/main/java/HearDay/spring/domain/usercalendar/entity/UserCalendar.java
+++ b/src/main/java/HearDay/spring/domain/usercalendar/entity/UserCalendar.java
@@ -1,4 +1,4 @@
-package HearDay.spring.domain.usercallendar.entity;
+package HearDay.spring.domain.usercalendar.entity;
 
 import HearDay.spring.common.entity.BaseEntity;
 import HearDay.spring.domain.user.entity.User;
@@ -13,12 +13,12 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(
-        name = "user_callendar",
+        name = "user_calendar",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"user_id", "attendance_date"})
         }
 )
-public class UserCallendar extends BaseEntity {
+public class UserCalendar extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/HearDay/spring/domain/usercalendar/repository/UserCalendarRepository.java
+++ b/src/main/java/HearDay/spring/domain/usercalendar/repository/UserCalendarRepository.java
@@ -1,0 +1,21 @@
+package HearDay.spring.domain.usercalendar.repository;
+
+import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.usercalendar.entity.UserCalendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface UserCalendarRepository extends JpaRepository<UserCalendar, Long> {
+
+    boolean existsByUserAndAttendanceDate(User user, LocalDate attendanceDate);
+
+    List<UserCalendar> findAllByUserAndAttendanceDateBetween(
+            User user,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+}

--- a/src/main/java/HearDay/spring/domain/usercalendar/service/UserCalendarService.java
+++ b/src/main/java/HearDay/spring/domain/usercalendar/service/UserCalendarService.java
@@ -1,0 +1,30 @@
+package HearDay.spring.domain.usercalendar.service;
+
+import HearDay.spring.domain.user.entity.User;
+import HearDay.spring.domain.usercalendar.entity.UserCalendar;
+import HearDay.spring.domain.usercalendar.repository.UserCalendarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class UserCalendarService {
+    private final UserCalendarRepository userCalendarRepository;
+
+    public void checkAttendance(User user) {
+        LocalDate today = LocalDate.now();
+
+        if (userCalendarRepository.existsByUserAndAttendanceDate(user, today)) {
+            return; // 오늘 이미 출석
+        }
+
+        UserCalendar attendance = UserCalendar.builder()
+                .user(user)
+                .attendanceDate(today)
+                .build();
+
+        userCalendarRepository.save(attendance);
+    }
+}

--- a/src/main/java/HearDay/spring/domain/usercallendar/entity/UserCallendar.java
+++ b/src/main/java/HearDay/spring/domain/usercallendar/entity/UserCallendar.java
@@ -1,0 +1,32 @@
+package HearDay.spring.domain.usercallendar.entity;
+
+import HearDay.spring.common.entity.BaseEntity;
+import HearDay.spring.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+        name = "user_callendar",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "attendance_date"})
+        }
+)
+public class UserCallendar extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "attendance_date", nullable = false)
+    private LocalDate attendanceDate;
+}


### PR DESCRIPTION
## 브랜치 번호

- feat/profile

## 작업 내용

- Calendar 테이블을 생성하였습니다.
- 프로필 화면에서 사용자 정보를 조회하는 API를 구현했습니다.
<img width="1409" height="662" alt="image" src="https://github.com/user-attachments/assets/792c07d5-4849-4f26-ad42-2629a9f8c530" />

- 뉴스 기사 상세 조회 시 출석체크가 되는 로직이라 함수 작성해서, 뉴스 상세 조회 서비스 코드에 추가해뒀습니다!
- 포인트 기능도 함수 작성해서 각각 서비스 코드에 추가해뒀습니다!

## 리뷰 요구사항

- 확인 부탁드립니다~~